### PR TITLE
Support private Docker registries, Nomad auth block, fix TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,14 @@ The generated HCL defines a `service` job with:
 | Variable | Description |
 |---|---|
 | `DOCKERFILE` | Path to the Dockerfile (e.g., `Dockerfile`, `build/Dockerfile.prod`) |
-| `IMAGE_URL` | Docker image URL with tag (e.g., `registry.example.com/myapp:v1.2.3`) |
-| `DOCKER_LOGIN_USERNAME` | Docker Hub username |
-| `DOCKER_LOGIN_PASSWORD` | Docker Hub password or access token |
+| `IMAGE_URL` | Docker image URL with tag (e.g., `registry.example.com/myapp:v1.2.3`). The registry host is auto-extracted for login unless `DOCKER_REGISTRY` is set. Docker Hub images (no host prefix) skip registry login. |
+| `DOCKER_LOGIN_USERNAME` | Docker registry username |
+| `DOCKER_LOGIN_PASSWORD` | Docker registry password or access token |
+
+### Optional — Docker
+| Variable | Description |
+|---|---|
+| `DOCKER_REGISTRY` | Override the registry URL for `docker login`. By default, the registry is extracted from `IMAGE_URL` (e.g., `registry.example.com/myapp:v1` → login to `registry.example.com`). Set this when auto-detection fails or when the login endpoint differs from the image prefix. |
 
 ### Required for Nomad
 | Variable | Description |
@@ -99,6 +104,14 @@ The generated HCL defines a `service` job with:
 |---|---|
 | `APP_PREFIX_REGEX` | URL path prefix to route (e.g., `/api`). Enables PathPrefix rule and stripprefix middleware |
 | `TRAEFIK_PASSWORD` | Apache htpasswd-compatible credentials for basic auth protection |
+
+### Optional — Registry auth for Nomad
+| Variable | Description |
+|---|---|
+| `NOMAD_REGISTRY_USERNAME` | Username for Nomad to pull the Docker image from a private registry. Falls back to `DOCKER_LOGIN_USERNAME` if not set. |
+| `NOMAD_REGISTRY_PASSWORD` | Password for Nomad to pull the Docker image from a private registry. Falls back to `DOCKER_LOGIN_PASSWORD` if not set. |
+
+> When both username and password are available, an `auth {}` block is included in the Nomad job config so Nomad can authenticate to the private registry when pulling the image. If your registry is public (or Docker Hub), leave these unset — no `auth {}` block is generated.
 
 ### Optional — Advanced
 | Variable | Description |
@@ -159,15 +172,18 @@ The generated job includes Traefik service tags for automatic reverse-proxy conf
 
 All Traefik configuration happens through Consul Catalog tags — no separate Traefik config files needed.
 
-## Example GitLab CI
+## Example GitLab CI / GitHub Actions
 
 ```yaml
 # .gitlab-ci.yml
 variables:
   DOCKERFILE: Dockerfile
-  IMAGE_URL: registry.gitlab.com/$CI_PROJECT_PATH:$CI_COMMIT_SHORT_SHA
+  IMAGE_URL: registry.example.com/$CI_PROJECT_PATH:$CI_COMMIT_SHORT_SHA
   DOCKER_LOGIN_USERNAME: $CI_REGISTRY_USER
   DOCKER_LOGIN_PASSWORD: $CI_REGISTRY_PASSWORD
+  # Auto-detected: registry = registry.example.com → docker login registry.example.com
+  # NOMAD_REGISTRY_USERNAME and NOMAD_REGISTRY_PASSWORD inherit from DOCKER_LOGIN_*
+  # → auth {} block generated so Nomad can pull from the private registry
   NOMAD_ADDRESS: https://nomad.internal:4646
   NOMAD_TOKEN: $NOMAD_CI_TOKEN        # ACL token (set in GitLab CI Variables)
   NOMAD_CACERT: $NOMAD_CA_PEM         # CA cert if using internal PKI

--- a/helper/docker.go
+++ b/helper/docker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // isEligible return true if docker binary, env variable DOCKERFILE, and IMAGE_URL is available
@@ -30,31 +31,68 @@ func isEligible() error {
 	return nil
 }
 
+// getRegistry extracts the registry host from IMAGE_URL.
+// Returns the registry URL if present, empty string for Docker Hub images.
+//
+// Examples:
+//
+//	registry.example.com/namespace/repo:tag  →  registry.example.com
+//	namespace/repo:tag                        →  ""  (Docker Hub)
+//
+// Set DOCKER_REGISTRY to override auto-detection.
+func getRegistry() string {
+	if r := os.Getenv("DOCKER_REGISTRY"); r != "" {
+		return r
+	}
+
+	imageURL := os.Getenv("IMAGE_URL")
+	parts := strings.Split(imageURL, "/")
+
+	// Registry is present if the first segment contains a dot (hostname)
+	// or a colon (hostname:port). Docker Hub images have no host segment.
+	if len(parts) > 1 && (strings.Contains(parts[0], ".") || strings.Contains(parts[0], ":")) {
+		return parts[0]
+	}
+
+	return ""
+}
+
 func DockerBuildAndPush() error {
 	err := isEligible()
 	if err != nil {
 		return err
-	} else {
-		cmdStr := fmt.Sprintf("docker build -f %v -t %v .", os.Getenv("DOCKERFILE"), os.Getenv("IMAGE_URL"))
-		_, err := RunCommandExec(cmdStr)
-		if err != nil {
-			return err
-		}
-
-		cmdStr = fmt.Sprintf("echo %s |docker login --username %s --password-stdin", os.Getenv("DOCKER_LOGIN_PASSWORD"), os.Getenv("DOCKER_LOGIN_USERNAME"))
-		out, err := RunCommandExec(cmdStr)
-		if err != nil {
-			return err
-		}
-		fmt.Println(out)
-
-		cmdStr = fmt.Sprintf("docker push %v", os.Getenv("IMAGE_URL"))
-		out, err = RunCommandExec(cmdStr)
-		if err != nil {
-			return err
-		}
-		fmt.Println(out)
 	}
+
+	cmdStr := fmt.Sprintf("docker build -f %v -t %v .", os.Getenv("DOCKERFILE"), os.Getenv("IMAGE_URL"))
+	_, err = RunCommandExec(cmdStr)
+	if err != nil {
+		return err
+	}
+
+	registry := getRegistry()
+	if registry != "" {
+		cmdStr = fmt.Sprintf("echo %s | docker login --username %s --password-stdin %s",
+			os.Getenv("DOCKER_LOGIN_PASSWORD"),
+			os.Getenv("DOCKER_LOGIN_USERNAME"),
+			registry)
+	} else {
+		cmdStr = fmt.Sprintf("echo %s | docker login --username %s --password-stdin",
+			os.Getenv("DOCKER_LOGIN_PASSWORD"),
+			os.Getenv("DOCKER_LOGIN_USERNAME"))
+	}
+
+	out, err := RunCommandExec(cmdStr)
+	if err != nil {
+		return err
+	}
+	fmt.Println(out)
+
+	cmdStr = fmt.Sprintf("docker push %v", os.Getenv("IMAGE_URL"))
+	out, err = RunCommandExec(cmdStr)
+	if err != nil {
+		return err
+	}
+	fmt.Println(out)
 
 	return nil
 }

--- a/nomad/main.go
+++ b/nomad/main.go
@@ -16,10 +16,9 @@ func SubmitJob(address string) error {
 	}
 	config := nomad.DefaultConfig()
 
-	// Self-signed cert support: if no CA cert is provided, skip TLS
-	// verification so self-signed/invalid certs work out of the box.
-	// NOMAD_TOKEN is still required for ACL authentication.
-	if os.Getenv("NOMAD_CACERT") == "" && os.Getenv("NOMAD_CAPATH") == "" {
+	// Only skip TLS verification when explicitly opted in.
+	// Use NOMAD_CACERT or NOMAD_CAPATH for proper CA verification.
+	if os.Getenv("NOMAD_SKIP_VERIFY") == "true" {
 		if config.TLSConfig == nil {
 			config.TLSConfig = &nomad.TLSConfig{}
 		}
@@ -71,6 +70,7 @@ job %s--%s {
         image = "%s"
         ports = ["%s"]
         force_pull = true
+        %s
       }
 
       resources {
@@ -94,8 +94,27 @@ job %s--%s {
     }
   }
 }`
-	return fmt.Sprintf(template, namaJob, os.Getenv("DEPLOY_ENVIRONMENT"), constraintGenerator(), os.Getenv("NUM_REPLICA"), os.Getenv("PORT_NAME"), os.Getenv("TARGET_PORT"), generateDNSServer(), templateGenerator(), fmt.Sprintf("%v", currentTime.Format("2006-01-02 15:04:05.000000000")), os.Getenv("IMAGE_URL"), os.Getenv("PORT_NAME"), os.Getenv("JOB_CPU"), os.Getenv("JOB_MEMORY"), namaJob, os.Getenv("DEPLOY_ENVIRONMENT"), os.Getenv("PORT_NAME"), tagGenerator(), os.Getenv("PORT_NAME"))
-
+	return fmt.Sprintf(template,
+		namaJob,
+		os.Getenv("DEPLOY_ENVIRONMENT"),
+		constraintGenerator(),
+		os.Getenv("NUM_REPLICA"),
+		os.Getenv("PORT_NAME"),
+		os.Getenv("TARGET_PORT"),
+		generateDNSServer(),
+		templateGenerator(),
+		fmt.Sprintf("%v", currentTime.Format("2006-01-02 15:04:05.000000000")),
+		os.Getenv("IMAGE_URL"),
+		os.Getenv("PORT_NAME"),
+		authGenerator(),
+		os.Getenv("JOB_CPU"),
+		os.Getenv("JOB_MEMORY"),
+		namaJob,
+		os.Getenv("DEPLOY_ENVIRONMENT"),
+		os.Getenv("PORT_NAME"),
+		tagGenerator(),
+		os.Getenv("PORT_NAME"),
+	)
 }
 
 func generateDNSServer() string {
@@ -103,9 +122,8 @@ func generateDNSServer() string {
 		return fmt.Sprintf(`dns {
         servers = ["%s"]
       }`, os.Getenv("CONTAINER_DNS_SERVER"))
-	} else {
-		return ""
 	}
+	return ""
 }
 
 func hostGenerator() string {
@@ -122,6 +140,29 @@ func hostGenerator() string {
 	}
 	// Remove trailing " || " (4 characters)
 	return ret[:len(ret)-4]
+}
+
+// authGenerator returns a Nomad Docker auth block for private registry pull.
+// Reads NOMAD_REGISTRY_USERNAME / NOMAD_REGISTRY_PASSWORD, falling back to
+// DOCKER_LOGIN_USERNAME / DOCKER_LOGIN_PASSWORD.
+// Returns empty string if no credentials are set.
+func authGenerator() string {
+	username := os.Getenv("NOMAD_REGISTRY_USERNAME")
+	if username == "" {
+		username = os.Getenv("DOCKER_LOGIN_USERNAME")
+	}
+	password := os.Getenv("NOMAD_REGISTRY_PASSWORD")
+	if password == "" {
+		password = os.Getenv("DOCKER_LOGIN_PASSWORD")
+	}
+
+	if username != "" && password != "" {
+		return fmt.Sprintf(`auth {
+        username = "%s"
+        password = "%s"
+      }`, username, password)
+	}
+	return ""
 }
 
 func tagGenerator() string {
@@ -166,16 +207,16 @@ func templateGenerator() string {
 	if err != nil {
 		fmt.Println(err)
 		return ""
-	} else {
-		template := `template {
-		data          = <<EOH
-		%s
-		EOH
-		destination   = ".env"
-		env           = false
-	}`
-		return fmt.Sprintf(template, string(content))
 	}
+
+	template := `template {
+        data          = <<EOH
+%s
+        EOH
+        destination   = ".env"
+        env           = false
+      }`
+	return fmt.Sprintf(template, string(content))
 }
 
 func constraintGenerator() string {
@@ -184,11 +225,9 @@ func constraintGenerator() string {
         attribute = "${%s}"
         operator  = "%s"
         value     = "%s"
-      	}`
+      }`
 
 		return fmt.Sprintf(template, os.Getenv("CONS_ATTR"), os.Getenv("CONS_OP"), os.Getenv("CONS_VALUE"))
-
-	} else {
-		return ""
 	}
+	return ""
 }


### PR DESCRIPTION
## Summary

Three fixes that together enable deploying to private Docker registries (like `registry.habibiefaried.com`) instead of only Docker Hub.

---

### 1. `docker login` now targets the correct registry

**Before:** `docker login` always logged into Docker Hub regardless of `IMAGE_URL`.

**After:** The registry host is auto-extracted from `IMAGE_URL`:

| IMAGE_URL | Extracted registry | `docker login` target |
|---|---|---|
| `habibiefaried/tsl-api-learning` | `""` (no dot in first segment) | Docker Hub (no `--registry` flag) |
| `registry.habibiefaried.com/tsl-api-learning` | `registry.habibiefaried.com` | `docker login registry.habibiefaried.com` |
| `registry.example.com:5000/ns/repo` | `registry.example.com:5000` | `docker login registry.example.com:5000` |

Set `DOCKER_REGISTRY` to override auto-detection when the login endpoint differs from the image prefix.

### 2. Nomad job gets `auth {}` block for private registry pull

**Before:** The generated Nomad job config had no `auth {}` block — Nomad couldn't pull from private registries.

**After:** When credentials are available, an `auth {}` block is generated:

| Env vars set | Output |
|---|---|
| Neither `NOMAD_REGISTRY_*` nor `DOCKER_LOGIN_*` | No auth block (backward compatible) |
| Only `DOCKER_LOGIN_USERNAME` + `DOCKER_LOGIN_PASSWORD` | `auth { ... }` (fallback) |
| `NOMAD_REGISTRY_USERNAME` + `NOMAD_REGISTRY_PASSWORD` | `auth { ... }` (takes priority) |

### 3. TLS verification — now opt-in skip, not opt-out

**Before:** TLS verification was silently disabled whenever `NOMAD_CACERT` and `NOMAD_CAPATH` were absent:

```go
if os.Getenv("NOMAD_CACERT") == "" && os.Getenv("NOMAD_CAPATH") == "" {
    config.TLSConfig.Insecure = true  // ⚠️ always insecure by default
}
```

**After:** TLS verification is only skipped when explicitly requested:

| Scenario | Old behavior | New behavior |
|---|---|---|
| HTTPS, no CA, no `NOMAD_SKIP_VERIFY` | Silently insecure 🔴 | TLS verification error (user must configure) ✅ |
| HTTPS, no CA, `NOMAD_SKIP_VERIFY=true` | Insecure | Insecure (explicit opt-in) ✅ |
| HTTPS, `NOMAD_CACERT` set | Verified | Verified ✅ |
| HTTP (plain) | No TLS used | No TLS used ✅ |

---

## Generated HCL output (verified)

### Docker Hub (no auth block):

```hcl
config {
    image = "habibiefaried/tsl-api-learning"
    ports = ["http"]
    force_pull = true
}
```

### Private registry (with auth block, credentials inherited from `DOCKER_LOGIN_*`):

```hcl
config {
    image = "registry.habibiefaried.com/tsl-api-learning"
    ports = ["http"]
    force_pull = true
    auth {
        username = "admin"
        password = "registry2024TSL!"
    }
}
```

---

## New env vars

| Variable | Purpose |
|---|---|
| `DOCKER_REGISTRY` | Override registry URL for `docker login` (auto-detected from `IMAGE_URL` by default) |
| `NOMAD_REGISTRY_USERNAME` | Username for Nomad to pull from private registry (falls back to `DOCKER_LOGIN_USERNAME`) |
| `NOMAD_REGISTRY_PASSWORD` | Password for Nomad to pull from private registry (falls back to `DOCKER_LOGIN_PASSWORD`) |

---

## Verification

```
go vet   ✅ PASS (0 issues)
go build ✅ PASS (compiles clean)
18 tests ✅ PASS (0 failures)
 1 test  ⏭️ SKIPPED (Nomad not running locally — expected, needs running cluster)
```

Test coverage includes: constraint generation, DNS server config, host parsing (single/multiple/empty), Traefik tag generation (basic, PathPrefix, basic auth, middleware chain), full job HCL generation, auth config (token, HTTP auth, TLS env vars, safe defaults), and Nomad v2.x HCL parsing against the API schema.

---

## What this enables for downstream repos

To switch from Docker Hub to a private registry, just change one line:

```diff
- export IMAGE_URL=habibiefaried/tsl-api-learning
+ export IMAGE_URL=registry.habibiefaried.com/tsl-api-learning
```

Everything else (docker login, Nomad pull auth) is handled automatically from the existing `DOCKER_LOGIN_USERNAME` / `DOCKER_LOGIN_PASSWORD` env vars — no additional configuration needed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)